### PR TITLE
Do not copy instruction with try-catch info on it

### DIFF
--- a/Source/RW_FacialStuff/Harmony/Optional/PrepC/PresetSaver_Postfix.cs
+++ b/Source/RW_FacialStuff/Harmony/Optional/PrepC/PresetSaver_Postfix.cs
@@ -36,7 +36,7 @@ namespace FacialStuff.Harmony.Optional.PrepC
                             typeof(PresetSaver_Postfix),
                             nameof(AddFaceToDictionary),
                             new[] { typeof(CustomPawn) }));
-                    yield return last;
+                    yield return new CodeInstruction(last.opcode, last.operand);
                 }
 
                 yield return itr;


### PR DESCRIPTION
Copying CodeInstructions with try-catch information will duplicate
unwanted try-catch structures. Normally not a problem since most
instructions have no try-catch info on them. This one does.